### PR TITLE
Tell pip how to find legacy jax versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,6 +22,10 @@ COPY --from=terraform /bin/terraform /usr/bin/
 
 COPY ./requirements.txt /tmp/pip-tmp/devcontainer-requirements.txt
 
+# Tell pip how to find legacy releases
 RUN pip3 install --no-cache-dir --upgrade pip \
-    && pip3 --no-cache-dir install -r /tmp/pip-tmp/devcontainer-requirements.txt \
+    && pip3 \
+    --no-cache-dir install \
+    --find-links https://storage.googleapis.com/jax-releases/jax_releases.html \
+    --requirement /tmp/pip-tmp/devcontainer-requirements.txt \
     && rm -rf /tmp/pip-tmp

--- a/examples/federated-learning/tff/distributed-fl-simulation-k8s/container-image/Dockerfile
+++ b/examples/federated-learning/tff/distributed-fl-simulation-k8s/container-image/Dockerfile
@@ -28,6 +28,7 @@ RUN pip install --no-cache-dir --upgrade pip
 
 RUN pip install \
     --no-cache-dir \
+    --find-links https://storage.googleapis.com/jax-releases/jax_releases.html \
     --requirement requirements.txt \
     && rm requirements.txt
 

--- a/examples/federated-learning/tff/image-classification/Dockerfile
+++ b/examples/federated-learning/tff/image-classification/Dockerfile
@@ -21,6 +21,7 @@ RUN pip install --no-cache-dir --upgrade pip
 
 RUN pip install \
     --no-cache-dir \
+    --find-links https://storage.googleapis.com/jax-releases/jax_releases.html \
     --requirement requirements.txt \
     && rm requirements.txt
 


### PR DESCRIPTION
[google/jax](https://github.com/google/jax) recently modified their release processes. That caused some versions to be unpublished from PyPI. With this change, we configure pip about where to look for legacy releases.