### PR TITLE
Add the service usage api prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ To deploy this blueprint you need:
 
 - A [Google Cloud project](https://cloud.google.com/docs/overview#projects) with billing enabled.
 - An account with the [Project Owner role](https://cloud.google.com/iam/docs/understanding-roles#resource-manager-roles) on the project.
+- The `serviceusage.googleapis.com` must be enabled on the project. For more
+  information about enabling APIs, see
+  [Enabling and disabling services](https://cloud.google.com/service-usage/docs/enable-disable)
 
 You create the infastructure using Terraform. The blueprint uses a local [Terraform backend](https://www.terraform.io/docs/language/settings/backends/configuration.html),
 but we recommend to configure a [remote backend](https://www.terraform.io/language/settings/backends/configuration#backend-types)


### PR DESCRIPTION
Add the `serviceusage.googleapis.com` API to the list of prerequisites. Without this API being enabled, Terraform cannot inspect service status, and fails.