### PR TITLE
fix: set a default value for workspace_bucket_name

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -195,6 +195,7 @@ variable "nvflare_namespace" {
 
 variable "workspace_bucket_name" {
   description = "Bucket name that will contain nvflare workspace"
+  default     = ""
   type        = string
 }
 


### PR DESCRIPTION
workspace_bucket_name is a variable that's only relevant for an example, and it shouldn't be a mandatory input.