### PR TITLE
chore(dependabot): add sub directories

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -57,6 +57,9 @@ updates:
           - release-please
   - directories:
       - /terraform
+      - /terraform/cross-device
+      - /terraform/nvflare
+      - /terraform/distributed-tff-example
     commit-message:
       prefix: "chore(deps)"
     package-ecosystem: "terraform"


### PR DESCRIPTION
This pull request includes updates to the `.github/dependabot.yaml` file to expand the directories monitored by Dependabot for Terraform dependencies.