### PR TITLE
chore: use a glob to select the entire repo for tf

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -56,10 +56,7 @@ updates:
           - commitlint
           - release-please
   - directories:
-      - /terraform
-      - /terraform/cross-device
-      - /terraform/nvflare
-      - /terraform/distributed-tff-example
+      - "**/*"
     commit-message:
       prefix: "chore(deps)"
     package-ecosystem: "terraform"


### PR DESCRIPTION
Use a glob expression to select the entire repository for Terraform updates.